### PR TITLE
feat(server-properties): Creation of ServerProperties System

### DIFF
--- a/src/main/java/org/sculk/Server.java
+++ b/src/main/java/org/sculk/Server.java
@@ -9,6 +9,8 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.logging.log4j.Logger;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerListPacket;
 import org.sculk.config.Config;
+import org.sculk.config.ServerProperties;
+import org.sculk.config.ServerPropertiesKeys;
 import org.sculk.console.TerminalConsole;
 import org.sculk.event.EventManager;
 import org.sculk.network.BedrockInterface;
@@ -58,7 +60,7 @@ public class Server {
     private final Path dataPath;
     private final Path pluginDataPath;
 
-    private final Config properties;
+    private final ServerProperties properties;
     private final Config config;
     private final Config operators;
     private final Config whitelist;
@@ -97,27 +99,9 @@ public class Server {
         this.config = new Config(this.dataPath + "/sculk.yml");
 
         logger.info("Loading {}...", TextFormat.AQUA + "server.properties" + TextFormat.WHITE);
-        this.properties = new Config(this.dataPath.resolve("server.properties").toString(), Config.PROPERTIES);
-        if(!this.properties.exists("server-port")) {
-            this.properties.set("language", "English");
-            this.properties.set("motd", "A Sculk Server Software");
-            this.properties.set("sub-motd", "Powered by Sculk");
-            this.properties.set("server-port", 19132);
-            this.properties.set("server-ip", "0.0.0.0");
-            this.properties.set("white-list", false);
-            this.properties.set("max-players", 20);
-            this.properties.set("gamemode", "Survival");
-            this.properties.set("pvp", true);
-            this.properties.set("difficulty", 1);
-            this.properties.set("level-name", "world");
-            this.properties.set("level-seed", "");
-            this.properties.set("level-type", "DEFAULT");
-            this.properties.set("auto-save", true);
-            this.properties.set("xbox-auth", true);
-            this.properties.save();
-        }
-        this.motd = this.properties.getString("motd");
-        this.submotd = this.properties.getString("sub-motd");
+        this.properties = new ServerProperties(this.dataPath);
+        this.motd = this.properties.get(ServerPropertiesKeys.MOTD, "A Sculk Server Software");
+        this.submotd = this.properties.get(ServerPropertiesKeys.SUB_MOTD, "Powered by Sculk");
 
         this.injector = Guice.createInjector(Stage.PRODUCTION, new SculkModule(this));
         this.eventManager = injector.getInstance(EventManager.class);
@@ -128,7 +112,7 @@ public class Server {
         this.banByName = new Config(this.dataPath.resolve("banned-players.txt").toString(), Config.ENUM);
         this.banByIp = new Config(this.dataPath.resolve("banned-ip.txt").toString(), Config.ENUM);
 
-        logger.info("Selected {} as the base language", this.properties.getString("language"));
+        logger.info("Selected {} as the base language", this.properties.get(ServerPropertiesKeys.LANGUAGE, "English"));
         logger.info("Starting Minecraft: Bedrock Edition server version {}", TextFormat.AQUA + Sculk.MINECRAFT_VERSION + TextFormat.WHITE);
 
         this.console = new TerminalConsole(this);
@@ -151,7 +135,7 @@ public class Server {
             shutdown();
         }
 
-        if(this.properties.getBoolean("xbox-auth")) {
+        if(this.properties.get(ServerPropertiesKeys.XBOX_AUTH, true)) {
             logger.info("Online mode is enable. The server will verify that players are authenticated to XboxLive.");
         } else {
             logger.info("{}Online mode is not enabled. The server no longer checks if players are authenticated to XboxLive.", TextFormat.RED);
@@ -216,7 +200,7 @@ public class Server {
         return Collections.unmodifiableMap(playerList);
     }
 
-    public Config getProperties() {
+    public ServerProperties getProperties() {
         return properties;
     }
 

--- a/src/main/java/org/sculk/config/ServerProperties.java
+++ b/src/main/java/org/sculk/config/ServerProperties.java
@@ -1,0 +1,122 @@
+package org.sculk.config;
+
+import java.io.File;
+import java.nio.file.Path;
+
+public class ServerProperties {
+    private final Config properties;
+
+    public ServerProperties(Path dataPath) {
+        File file = new File(dataPath + "/server.properties");
+        if (!file.exists()) {
+            ConfigSection defaults = getDefaultValues();
+            new Config(file.getPath(), Config.PROPERTIES, defaults).save();
+        }
+        this.properties = new Config(dataPath + "/server.properties", Config.PROPERTIES, getDefaultValues());
+    }
+
+    private ConfigSection getDefaultValues() {
+        ConfigSection defaults = new ConfigSection();
+        defaults.put(ServerPropertiesKeys.LANGUAGE.toString(), "English");
+        defaults.put(ServerPropertiesKeys.MOTD.toString(), "A Sculk Server Software");
+        defaults.put(ServerPropertiesKeys.SUB_MOTD.toString(), "Powered by Sculk");
+        defaults.put(ServerPropertiesKeys.SERVER_IP.toString(), "0.0.0.0");
+        defaults.put(ServerPropertiesKeys.SERVER_PORT.toString(), 19132);
+        defaults.put(ServerPropertiesKeys.WHITELIST.toString(), "off");
+        defaults.put(ServerPropertiesKeys.MAX_PLAYERS.toString(), 20);
+        defaults.put(ServerPropertiesKeys.GAMEMODE.toString(), 0);
+        defaults.put(ServerPropertiesKeys.PVP.toString(), "on");
+        defaults.put(ServerPropertiesKeys.DIFFICULTY.toString(), 1);
+        defaults.put(ServerPropertiesKeys.LEVEL_NAME.toString(), "world");
+        defaults.put(ServerPropertiesKeys.LEVEL_SEED.toString(), "");
+        defaults.put(ServerPropertiesKeys.LEVEL_TYPE.toString(), "DEFAULT");
+        defaults.put(ServerPropertiesKeys.AUTO_SAVE.toString(), "on");
+        defaults.put(ServerPropertiesKeys.XBOX_AUTH.toString(), "on");
+        return defaults;
+    }
+
+    public ConfigSection getProperties() {
+        return this.properties.getRootSection();
+    }
+
+    public Integer get(ServerPropertiesKeys key, Integer defaultValue) {
+        Object value = this.properties.get(key.toString());
+        if (value instanceof String) {
+            try {
+                return Integer.parseInt((String) value);
+            } catch (NumberFormatException e) {
+                return defaultValue;
+            }
+        } else if (value instanceof Integer) {
+            return (Integer) value;
+        } else {
+            return defaultValue;
+        }
+    }
+
+    public String get(ServerPropertiesKeys key, String defaultValue) {
+        Object value = this.properties.get(key.toString());
+        if (value instanceof String) {
+            return (String) value;
+        } else {
+            return defaultValue;
+        }
+    }
+
+    public Boolean get(ServerPropertiesKeys key, Boolean defaultValue) {
+        Object value = this.properties.get(key.toString());
+        if (value instanceof String) {
+            String stringValue = ((String) value).toLowerCase();
+            if (stringValue.equals("on")) {
+                return true;
+            } else if (stringValue.equals("off")) {
+                return false;
+            }
+        } else if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return defaultValue;
+    }
+
+    public Long get(ServerPropertiesKeys key, Long defaultValue) {
+        Object value = this.properties.get(key.toString());
+        if (value instanceof String stringValue) {
+            if (!stringValue.isEmpty()) {
+                try {
+                    return Long.parseLong(stringValue);
+                } catch (NumberFormatException e) {
+                    return defaultValue;
+                }
+            } else {
+                return defaultValue;
+            }
+        } else if (value instanceof Long) {
+            return (Long) value;
+        } else {
+            return defaultValue;
+        }
+    }
+
+    public void set(String key, Object value) {
+        if (value instanceof Boolean) {
+            value = (Boolean) value ? "on" : "off";
+        }
+        this.properties.set(key, value);
+    }
+
+    public void remove(String key) {
+        this.properties.remove(key);
+    }
+
+    public boolean exists(String key) {
+        return this.properties.exists(key);
+    }
+
+    public void save() {
+        this.properties.save();
+    }
+
+    public void reload() {
+        this.properties.reload();
+    }
+}

--- a/src/main/java/org/sculk/config/ServerProperties.java
+++ b/src/main/java/org/sculk/config/ServerProperties.java
@@ -30,6 +30,8 @@ public class ServerProperties {
         defaults.put(ServerPropertiesKeys.LEVEL_NAME.toString(), "world");
         defaults.put(ServerPropertiesKeys.LEVEL_SEED.toString(), "");
         defaults.put(ServerPropertiesKeys.LEVEL_TYPE.toString(), "DEFAULT");
+        defaults.put(ServerPropertiesKeys.SPAWN_ANIMALS.toString(), "on");
+        defaults.put(ServerPropertiesKeys.SPAWN_MONSTERS.toString(), "on");
         defaults.put(ServerPropertiesKeys.AUTO_SAVE.toString(), "on");
         defaults.put(ServerPropertiesKeys.XBOX_AUTH.toString(), "on");
         return defaults;

--- a/src/main/java/org/sculk/config/ServerPropertiesKeys.java
+++ b/src/main/java/org/sculk/config/ServerPropertiesKeys.java
@@ -1,0 +1,33 @@
+package org.sculk.config;
+
+public enum ServerPropertiesKeys {
+    LANGUAGE("language"),
+    MOTD("motd"),
+    SUB_MOTD("sub-motd"),
+    SERVER_PORT("server-port"),
+    SERVER_IP("server-ip"),
+    WHITELIST("white-list"),
+    MAX_PLAYERS("max-players"),
+    GAMEMODE("gamemode"),
+    PVP("pvp"),
+    DIFFICULTY("difficulty"),
+    LEVEL_NAME("level-name"),
+    LEVEL_SEED("level-seed"),
+    LEVEL_TYPE("level-type"),
+    AUTO_SAVE("auto-save"),
+    XBOX_AUTH("xbox-auth");
+
+    public static final String ON = "on";
+    public static final String OFF = "false";
+
+    private final String key;
+
+    ServerPropertiesKeys(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String toString() {
+        return key;
+    }
+}

--- a/src/main/java/org/sculk/config/ServerPropertiesKeys.java
+++ b/src/main/java/org/sculk/config/ServerPropertiesKeys.java
@@ -17,9 +17,6 @@ public enum ServerPropertiesKeys {
     AUTO_SAVE("auto-save"),
     XBOX_AUTH("xbox-auth");
 
-    public static final String ON = "on";
-    public static final String OFF = "false";
-
     private final String key;
 
     ServerPropertiesKeys(String key) {

--- a/src/main/java/org/sculk/config/ServerPropertiesKeys.java
+++ b/src/main/java/org/sculk/config/ServerPropertiesKeys.java
@@ -14,6 +14,8 @@ public enum ServerPropertiesKeys {
     LEVEL_NAME("level-name"),
     LEVEL_SEED("level-seed"),
     LEVEL_TYPE("level-type"),
+    SPAWN_ANIMALS("spawn-animals"),
+    SPAWN_MONSTERS("spawn-monsters"),
     AUTO_SAVE("auto-save"),
     XBOX_AUTH("xbox-auth");
 


### PR DESCRIPTION
## Description

This pull request introduces a new `ServerProperties` system to manage the server's configuration properties in a more structured and maintainable way. The changes replace the previous use of `Config` with the newly created `ServerProperties` class and the associated `ServerPropertiesKeys` enum.

### Key Changes

- **Server.java**: 
  - Replaced the `Config` instance managing `server.properties` with `ServerProperties`.
  - Removed hardcoded property keys and replaced them with keys from `ServerPropertiesKeys`.
  - Updated methods to use the new `ServerProperties` system for retrieving and setting configuration properties.

- **ServerProperties.java**:
  - A new class to handle server properties with predefined default values.
  - Provides methods for retrieving properties with type safety (e.g., `String`, `Integer`, `Boolean`, etc.).
  - Simplifies setting and getting property values with appropriate type casting.

- **ServerPropertiesKeys.java**:
  - An enum containing all the keys used in the `server.properties` file.
  - Ensures that all keys are centralized and consistent across the codebase.

## Changes Overview

- **Files Modified**: 2 files modified (`Server.java` and `ServerProperties.java`)
- **Files Added**: 2 files added (`ServerProperties.java`, `ServerPropertiesKeys.java`)
- **Lines Added**: 164 lines
- **Lines Removed**: 25 lines

## Code Review

### Additions:

- **Server.java**:
  - Added `import org.sculk.config.ServerProperties;`
  - Added `import org.sculk.config.ServerPropertiesKeys;`
  - Initialized `ServerProperties` instead of `Config` for server properties.
  - Updated logging and configuration retrieval methods.

- **ServerProperties.java**:
  - Added logic for initializing and managing server properties with default values.
  - Created methods for safe retrieval of different data types (e.g., `String`, `Integer`, `Boolean`).

- **ServerPropertiesKeys.java**:
  - Enum to define keys used in `ServerProperties`.

### Deletions:

- **Server.java**:
  - Removed hardcoded string literals for property keys.
  - Removed old `Config` initialization for `server.properties`.

## Testing

- Tested the new `ServerProperties` system with existing server configurations.
- Ensured all properties load correctly with their respective types.
- Verified that default values are applied when properties are missing.

@AzaleeX