### PR TITLE
feat(submotd): Add `getSubMotd` method and fix level name retrieval

### DIFF
--- a/src/main/java/org/sculk/Server.java
+++ b/src/main/java/org/sculk/Server.java
@@ -286,6 +286,10 @@ public class Server {
         return motd;
     }
 
+    public String getSubMotd() {
+        return submotd;
+    }
+
     public UUID getServerId() {
         return serverId;
     }

--- a/src/main/java/org/sculk/network/handler/PreSpawnPacketHandler.java
+++ b/src/main/java/org/sculk/network/handler/PreSpawnPacketHandler.java
@@ -83,7 +83,7 @@ public class PreSpawnPacketHandler extends SculkPacketHandler {
         startGamePacket.setEducationProductionId("");
         startGamePacket.setForceExperimentalGameplay(OptionalBoolean.empty());
 
-        String serverName = session.getServer().getMotd();
+        String serverName = session.getServer().getSubMotd();
         startGamePacket.setLevelId(serverName);
         startGamePacket.setLevelName(serverName);
 


### PR DESCRIPTION
This pull request introduces a new method `getSubMotd` in the `Server` class to retrieve the sub-message of the day (subMotd). Additionally, it fixes the retrieval of the world name in the `PreSpawnPacketHandler` by switching from `getMotd` to `getSubMotd`.

## Changes
- **Server.java**: Added the `getSubMotd` method to the `Server` class.
- **PreSpawnPacketHandler.java**: Replaced the usage of `getMotd` with `getSubMotd` for level name retrieval.