### PR TITLE
Add PlayerJoinEvent and broadcast join messages

### DIFF
--- a/src/main/java/org/sculk/event/player/PlayerJoinEvent.java
+++ b/src/main/java/org/sculk/event/player/PlayerJoinEvent.java
@@ -1,0 +1,37 @@
+package org.sculk.event.player;
+
+
+import org.sculk.player.Player;
+
+/*
+ *   ____             _ _
+ *  / ___|  ___ _   _| | | __
+ *  \___ \ / __| | | | | |/ /
+ *   ___) | (__| |_| | |   <
+ *  |____/ \___|\__,_|_|_|\_\
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author: SculkTeams
+ * @link: http://www.sculkmp.org/
+ */
+public class PlayerJoinEvent extends PlayerEvent {
+
+    protected String joinMessage;
+
+    public PlayerJoinEvent(Player player, String joinMessage) {
+        super(player);
+        this.joinMessage = joinMessage;
+    }
+
+    public String getJoinMessage() {
+        return joinMessage;
+    }
+
+    public void setJoinMessage(String joinMessage) {
+        this.joinMessage = joinMessage;
+    }
+}

--- a/src/main/java/org/sculk/lang/LanguageKeys.java
+++ b/src/main/java/org/sculk/lang/LanguageKeys.java
@@ -23,7 +23,9 @@ public enum LanguageKeys {
     SCULK_PLUGINS_DISABLED("sculk.plugins.disabled"),
     SCULK_NETWORK_INTERFACES_STOPPING("sculk.network.interfaces.stopping"),
     SCULK_CONSOLE_CLOSING("sculk.console.closing"),
-    SCULK_THREADS_STOPPING("sculk.threads.stopping");
+    SCULK_THREADS_STOPPING("sculk.threads.stopping"),
+
+    MINECRAFT_PLAYER_JOIN("multiplayer.player.joined");
 
     private final String key;
 

--- a/src/main/java/org/sculk/network/handler/SpawnResponsePacketHandler.java
+++ b/src/main/java/org/sculk/network/handler/SpawnResponsePacketHandler.java
@@ -3,12 +3,14 @@ package org.sculk.network.handler;
 
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetLocalPlayerAsInitializedPacket;
-import org.cloudburstmc.protocol.bedrock.packet.TextPacket;
 import org.cloudburstmc.protocol.common.PacketSignal;
 import org.sculk.Server;
+import org.sculk.event.player.PlayerJoinEvent;
+import org.sculk.lang.LanguageKeys;
 import org.sculk.network.session.SculkServerSession;
 import org.sculk.utils.TextFormat;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 /*
@@ -44,6 +46,10 @@ public class SpawnResponsePacketHandler extends SculkPacketHandler {
     public PacketSignal handle(SetLocalPlayerAsInitializedPacket packet) {
         this.responseCallback.accept(null);
         Server.getInstance().getLogger().info("§b" + session.getPlayer().getName() + "[/" + session.getPlayerInfo().getServerAddress() + "] logged in with uuid " + session.getPlayer().getUniqueId());
+
+        PlayerJoinEvent playerJoinEvent = new PlayerJoinEvent(session.getPlayer(), session.getPlayer().getLanguage().translate(LanguageKeys.MINECRAFT_PLAYER_JOIN, List.of(session.getPlayer().getName())));
+        playerJoinEvent.call();
+        Server.getInstance().broadcastMessage(TextFormat.YELLOW + playerJoinEvent.getJoinMessage() + TextFormat.RESET);
         return PacketSignal.HANDLED;
     }
 }

--- a/src/main/resources/language/en_GB.ini
+++ b/src/main/resources/language/en_GB.ini
@@ -23,3 +23,5 @@ sculk.console.closing=Closing console
 sculk.threads.stopping=Stopping other threads
 
 sculk.command.list=Lists connected players
+
+multiplayer.player.joined = has joined the game


### PR DESCRIPTION
Introduced the PlayerJoinEvent class to handle player join events and broadcast customizable join messages. Updated the SpawnResponsePacketHandler to trigger and call the event while broadcasting the localized join message. Added a new localization key for the join message in the LanguageKeys class and language resource file.